### PR TITLE
Adds journal bootstrapping for pre-existing database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +386,8 @@ dependencies = [
  "chrono",
  "clap",
  "serde",
+ "serde_sqlite",
+ "tempfile",
 ]
 
 [[package]]
@@ -466,6 +486,8 @@ version = "0.1.0"
 dependencies = [
  "journal",
  "libsqlite-sys",
+ "page_parser",
+ "serde_sqlite",
  "ureq",
 ]
 
@@ -509,6 +531,15 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "page_parser"
+version = "0.1.0"
+dependencies = [
+ "block",
+ "serde",
+ "serde_sqlite",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -571,6 +602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +624,15 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -669,6 +718,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_sqlite"
+version = "0.1.0"
+dependencies = [
+ "block",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +752,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,6 @@ members = [
     "journal",
     "libsqlite-sys",
     "mycelite",
+    "page_parser",
+    "serde_sqlite",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "chrono",
  "clap",
  "serde",
+ "serde_sqlite",
 ]
 
 [[package]]
@@ -1067,6 +1068,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_sqlite"
+version = "0.1.0"
+dependencies = [
+ "block",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1173,7 @@ dependencies = [
  "journal",
  "libsqlite-sys",
  "serde",
+ "serde_sqlite",
  "tokio",
  "tokio-util",
  "tracing",

--- a/examples/sync-backend/Cargo.toml
+++ b/examples/sync-backend/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 libsqlite-sys = { path = "../../libsqlite-sys" }
 journal = { path = "../../journal" }
+serde_sqlite = { path = "../../serde_sqlite" }
 
 tokio = { version = "1", features = ["full"] }
 axum  = { version = "0.6", features = ["headers"] }

--- a/examples/sync-backend/src/main.rs
+++ b/examples/sync-backend/src/main.rs
@@ -24,7 +24,8 @@ use axum::{
     Router, Server,
 };
 use futures::StreamExt;
-use journal::{de, se, Journal, PageHeader, SnapshotHeader};
+use journal::{Journal, PageHeader, SnapshotHeader};
+use serde_sqlite::{se, de};
 use std::io::Read;
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/journal/src/lib.rs
+++ b/journal/src/lib.rs
@@ -1,9 +1,5 @@
-pub mod de;
 mod error;
 mod journal;
-pub mod se;
 
-pub use crate::de::{from_bytes, from_reader};
 pub use crate::error::Error;
 pub use crate::journal::{Journal, PageHeader, SnapshotHeader};
-pub use crate::se::to_bytes;

--- a/journal/tests/journal_tests.rs
+++ b/journal/tests/journal_tests.rs
@@ -1,0 +1,15 @@
+use journal::Journal;
+
+#[cfg(test)]
+use tempfile;
+
+#[test]
+fn test_journal_not_exists() {
+    // create named temp file and delete
+    let name = &tempfile::NamedTempFile::new().unwrap();
+    std::fs::remove_file(name).unwrap();
+    let res = Journal::try_from(name);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(err.journal_not_exists());
+}

--- a/mycelite/Cargo.toml
+++ b/mycelite/Cargo.toml
@@ -12,6 +12,8 @@ test = false
 [dependencies]
 libsqlite-sys = { path = "../libsqlite-sys" }
 journal = { path = "../journal" }
+page_parser = { path = "../page_parser" }
+serde_sqlite = { path = "../serde_sqlite" }
 
 # replicator
 ureq = { version = "2.5" }

--- a/mycelite/src/lib.rs
+++ b/mycelite/src/lib.rs
@@ -11,6 +11,7 @@ use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::mem;
 use std::os::unix::fs::FileExt;
 use std::ptr;
+use page_parser;
 
 libsqlite_sys::setup!();
 
@@ -83,9 +84,9 @@ impl MclVFS {
 #[repr(C)]
 struct MclVFSFile {
     base: ffi::sqlite3_file,
-    journal: Option<std::mem::ManuallyDrop<Journal>>,
+    journal: Option<mem::ManuallyDrop<Journal>>,
     read_only: bool,
-    replicator: Option<std::mem::ManuallyDrop<replicator::ReplicatorHandle>>,
+    replicator: Option<mem::ManuallyDrop<replicator::ReplicatorHandle>>,
     vfs: *mut ffi::sqlite3_vfs,
     real: ffi::sqlite3_file,
 }
@@ -94,6 +95,31 @@ impl MclVFSFile {
     /// downcast pfile ptr to MclVFSFile struct ptr
     unsafe fn from_ptr(pfile: *mut ffi::sqlite3_file) -> &'static mut Self {
         &mut *(pfile as *mut MclVFSFile)
+    }
+
+    /// bootstrap journal
+    ///
+    /// happens only once on journal creation.
+    fn bootstrap_journal(&self, journal: &mut Journal, database_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let db = page_parser::Database::new(database_path);
+        let iter = match db.into_raw_page_iter() {
+            Ok(iter) => iter,
+            Err(e) => {
+                if let Some(err) = e.downcast_ref::<std::io::Error>() {
+                    if err.kind() == std::io::ErrorKind::NotFound {
+                        // no database file - no need in bootstraping
+                        return Ok(())
+                    }
+                }
+                return Err(e)
+            }
+        };
+        for page in iter {
+            let page = page?;
+            let page = page.as_slice();
+            journal.add_page(page.len() as u64, page)?;
+        }
+        journal.commit().map_err(Into::into)
     }
 
     unsafe fn setup_journal(
@@ -114,12 +140,19 @@ impl MclVFSFile {
             s.push_str("-mycelial");
             s
         };
+        let journal = match Journal::try_from(&journal_path) {
+            Ok(j) => j,
+            Err(e) if e.journal_not_exists() => {
+                let mut journal = Journal::create(&journal_path)?;
+                self.bootstrap_journal(&mut journal, &database_path)?;
+                journal
+            },
+            Err(e) => return Err(e.into()),
+        };
+        self.journal = Some(mem::ManuallyDrop::new(journal));
 
-        self.journal = Some(std::mem::ManuallyDrop::new(
-            Journal::try_from(&journal_path).or_else(|_e| Journal::create(&journal_path))?,
-        ));
         let url = std::env::var("MYCELIAL_SYNC_BACKEND").unwrap_or("http://localhost:8080".into());
-        self.replicator = Some(std::mem::ManuallyDrop::new(
+        self.replicator = Some(mem::ManuallyDrop::new(
             replicator::Replicator::new(url, &journal_path, database_path, self.read_only).spawn()
         ));
         Ok(())
@@ -263,10 +296,10 @@ static MclVFSIO: ffi::sqlite3_io_methods = ffi::sqlite3_io_methods {
 
 unsafe extern "C" fn mvfs_io_close(pfile: *mut ffi::sqlite3_file) -> c_int {
     let file = MclVFSFile::from_ptr(pfile);
-    file.journal.take().map(std::mem::ManuallyDrop::into_inner);
+    file.journal.take().map(mem::ManuallyDrop::into_inner);
     file.replicator
         .take()
-        .map(std::mem::ManuallyDrop::into_inner);
+        .map(mem::ManuallyDrop::into_inner);
     (&*file.real.pMethods).xClose.unwrap()(&mut file.real)
 }
 

--- a/mycelite/src/replicator.rs
+++ b/mycelite/src/replicator.rs
@@ -2,7 +2,8 @@
 //!
 //! ** For demo use only! **
 
-use journal::{de, se, Journal, PageHeader, SnapshotHeader};
+use journal::{Journal, PageHeader, SnapshotHeader};
+use serde_sqlite::{de, se};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender, TryRecvError};

--- a/page_parser/Cargo.toml
+++ b/page_parser/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
-name = "journal"
+name = "page_parser"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-block = { path = "../block" }
-clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-chrono = "0.4"
 serde_sqlite = { path = "../serde_sqlite" }
-
-[dev-dependencies]
-tempfile = "3"
+block = { path = "../block" }

--- a/page_parser/README.md
+++ b/page_parser/README.md
@@ -1,0 +1,1 @@
+## Sqlite Page Parser

--- a/page_parser/src/database.rs
+++ b/page_parser/src/database.rs
@@ -1,0 +1,69 @@
+//! Sqlite Database
+use crate::header::Header;
+use crate::page::RawPage;
+use serde_sqlite::from_bytes;
+use std::io::BufReader;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Database {
+    path: PathBuf,
+}
+
+impl Database {
+    pub fn new<P: Into<PathBuf>>(p: P) -> Self {
+        Self { path: p.into() }
+    }
+
+    /// Initialize iterator over raw sqlite pages
+    pub fn into_raw_page_iter(&self) -> Result<RawPageIter, Box<dyn std::error::Error>> {
+        let mut fd = std::fs::OpenOptions::new()
+            .read(true)
+            .open(self.path.as_path())?;
+        let db_size = fd.metadata()?.len();
+        let (page_size, pages_left) = match db_size {
+            0 => (0, 0),
+            _ => {
+                let mut buf = [0_u8; 100];
+                fd.read_exact(buf.as_mut_slice())?;
+                let header = from_bytes::<Header>(buf.as_slice())?;
+                let page_size = header.page_size() as u64;
+                (page_size, db_size / page_size)
+            }
+        };
+        fd.seek(SeekFrom::Start(0))?;
+        Ok(RawPageIter {
+            fd: BufReader::new(fd),
+            page_size,
+            pages_left,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct RawPageIter {
+    // for now only file iter, but in-memory option also can be supported
+    fd: BufReader<std::fs::File>,
+    page_size: u64,
+    pages_left: u64,
+}
+
+impl Iterator for RawPageIter {
+    type Item = Result<RawPage, std::io::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pages_left == 0 {
+            return None;
+        };
+        self.pages_left -= 1;
+        let mut page = vec![0; self.page_size as usize];
+        match self.fd.read_exact(page.as_mut_slice()) {
+            Ok(_) => Some(Ok(RawPage::new(page))),
+            Err(e) => {
+                self.pages_left = 0;
+                Some(Err(e))
+            }
+        }
+    }
+}

--- a/page_parser/src/header.rs
+++ b/page_parser/src/header.rs
@@ -1,0 +1,74 @@
+//! [Sqlite Database Header]<https://www.sqlite.org/fileformat.html#the_database_header>
+
+use block::block;
+use serde::{Deserialize, Serialize};
+use serde_sqlite;
+
+/// sqlite database header
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[block(100)]
+pub struct Header {
+    /// sqlite header magic: 'SQLite format 3\0'
+    pub magic: [u8; 16],
+    /// sqlite page size, values of power of two between 512 and 32768 inclusive, or the value 1 representing a page size of 65536
+    pub page_size: u16,
+    /// file format write version: 1 for legacy, 2 for WAL
+    pub write_version: u8,
+    /// file format read vresion: 1 for legacy, 2 for WAL
+    pub read_version: u8,
+    // reserved
+    _reserved_1: u8,
+    /// max embedded payload fraction, must be 64
+    pub max_embedded_payload_fraction: u8,
+    /// min embedded payload fraction, must be 32
+    pub min_embedded_payload_fraction: u8,
+    /// leaf payload fraction
+    pub leaf_payload_fraction: u8,
+    /// file change counter
+    pub file_change_counter: u32,
+    /// size of the database file in pages, the "in-header database size"
+    pub database_size: u32,
+    /// page number of the first freelist trunk page
+    #[serde(
+        deserialize_with = "serde_sqlite::de::zero_as_none",
+        serialize_with = "serde_sqlite::se::none_as_zero"
+    )]
+    pub first_freelist_page_num: Option<u32>,
+    /// total number of freelist pages
+    pub freelist_pages_total: u32,
+    /// schema cookie
+    pub schema_cookie: u32,
+    /// schema format number, supported values are 1, 2, 3 and 4
+    pub schema_format_num: u32,
+    /// default page cache size
+    pub default_page_cache_size: u32,
+    /// page number of largest root b-tree page when in auto-vacuum or incremental vacuum modes, zero otherwise
+    pub largest_root: u32,
+    /// db text encoding:
+    /// UTF-8    - 1
+    /// UTF-16le - 2
+    /// UTF-16be - 3
+    pub text_encoding: u32,
+    /// user version, set by user version pragma
+    pub user_version: u32,
+    /// incremental vacuum mode flag, true if not 0, false otherwize
+    pub inc_vacuum_mode: u32,
+    /// application id, set by pragma application id
+    pub application_id: u32,
+    // reserved
+    _reserved_2: [u8; 20],
+    // offset: 72, size: 20
+    /// version of sqlite which modified database recently
+    pub version_valid_for_number: u32,
+    /// sqlite version number
+    pub version: u32,
+}
+
+impl Header {
+    pub fn page_size(&self) -> u32 {
+        match self.page_size {
+            1 => 0x10000,
+            v => v as u32,
+        }
+    }
+}

--- a/page_parser/src/lib.rs
+++ b/page_parser/src/lib.rs
@@ -1,0 +1,7 @@
+pub(crate) mod database;
+pub(crate) mod header;
+pub(crate) mod page;
+
+pub use database::Database;
+pub use header::Header;
+pub use page::RawPage;

--- a/page_parser/src/page.rs
+++ b/page_parser/src/page.rs
@@ -1,0 +1,17 @@
+//! Sqlite Page
+
+/// Sqlite Raw Page
+///
+/// Just a chunk of bytes representing sqlite database page
+#[derive(Debug)]
+pub struct RawPage(Vec<u8>);
+
+impl RawPage {
+    pub fn new(page: Vec<u8>) -> Self {
+        Self(page)
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}

--- a/page_parser/tests/header_test.rs
+++ b/page_parser/tests/header_test.rs
@@ -1,0 +1,250 @@
+//! validate sqlite header deserializer/serialiser.
+//! deserialized version compared against manually parsed version.
+//! serialized version should produce exact header is was deserialized from.
+
+use page_parser::Header;
+use serde_sqlite;
+use std::ffi::CStr;
+
+// real sqlite3 header
+static HEADER: [u8; 100] = [
+    0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00,
+    0x10, 0x00, 0x01, 0x01, 0x00, 0x40, 0x20, 0x20, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x2e, 0x63, 0x00,
+];
+
+/// manually parsed header
+#[derive(Debug, Clone)]
+pub struct TestHeader {
+    pub magic: [u8; 16],
+    pub page_size: u32,
+    pub write_version: u8,
+    pub read_version: u8,
+    pub max_embedded_payload_fraction: u8,
+    pub min_embedded_payload_fraction: u8,
+    pub leaf_payload_fraction: u8,
+    pub file_change_counter: u32,
+    pub db_size: u32,
+    pub first_free_page_num: Option<u32>,
+    pub freelist_total: u32,
+    pub schema_cookie: u32,
+    pub schema_format_num: u32,
+    pub default_page_cache_size: u32,
+    pub largest_root: u32,
+    pub text_encoding: u32,
+    pub user_version: u32,
+    pub inc_vacuum_mode: u32,
+    pub application_id: u32,
+    pub version_valid_for_number: u32,
+    pub version: u32,
+}
+
+macro_rules! slc {
+    ($buf:ident, $offset:expr, $len:expr) => {
+        $buf[$offset..($offset + $len)]
+    };
+    ($buf:ident, $offset:expr, $len:expr, $t:ty) => {
+        <$t>::from_be_bytes(slc!($buf, $offset, $len).try_into()?)
+    };
+}
+
+impl TryFrom<&[u8; 100]> for TestHeader {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(buf: &[u8; 100]) -> Result<Self, Self::Error> {
+        Ok(Self::new(
+            {
+                let mut magic = [0_u8; 16];
+                magic.copy_from_slice(&buf[..16]);
+                magic
+            }, // header
+            slc!(buf, 16, 2, u16),                               // page size
+            slc!(buf, 18, 1, u8),                                // write_version
+            slc!(buf, 19, 1, u8),                                // read_version
+            slc!(buf, 21, 1, u8),                                // max_embedded_payload_fraction
+            slc!(buf, 22, 1, u8),                                // min_embedded_payload_fraction
+            slc!(buf, 23, 1, u8),                                // leaf_payload_fraction
+            slc!(buf, 24, 4, u32),                               // file_change_counter
+            slc!(buf, 28, 4, u32),                               // db_size
+            slc!(buf, 32, 4, u32).checked_sub(1).map(|x| x + 1), // first_free_page_num
+            slc!(buf, 36, 4, u32),                               // freelist_total
+            slc!(buf, 40, 4, u32),                               // schema_cookie
+            slc!(buf, 44, 4, u32),                               // schema_format_num
+            slc!(buf, 48, 4, u32),                               // default_page_cache
+            slc!(buf, 52, 4, u32),                               // largest_root
+            slc!(buf, 56, 4, u32),                               // text_encoding
+            slc!(buf, 60, 4, u32),                               // user_version
+            slc!(buf, 64, 4, u32),                               // inc_vacuum_mode
+            slc!(buf, 68, 4, u32),                               // application_id
+            slc!(buf, 92, 4, u32),                               // version_valid_for_number
+            slc!(buf, 96, 4, u32),                               // version
+        ))
+    }
+}
+
+impl TestHeader {
+    pub fn new(
+        magic: [u8; 16],
+        page_size: u16,
+        write_version: u8,
+        read_version: u8,
+        max_embedded_payload_fraction: u8,
+        min_embedded_payload_fraction: u8,
+        leaf_payload_fraction: u8,
+        file_change_counter: u32,
+        db_size: u32,
+        first_free_page_num: Option<u32>,
+        freelist_total: u32,
+        schema_cookie: u32,
+        schema_format_num: u32,
+        default_page_cache_size: u32,
+        largest_root: u32,
+        text_encoding: u32,
+        user_version: u32,
+        inc_vacuum_mode: u32,
+        application_id: u32,
+        version_valid_for_number: u32,
+        version: u32,
+    ) -> Self {
+        Self {
+            magic,
+            page_size: Self::to_page_size(page_size),
+            write_version,
+            read_version,
+            max_embedded_payload_fraction,
+            min_embedded_payload_fraction,
+            leaf_payload_fraction,
+            file_change_counter,
+            db_size,
+            first_free_page_num,
+            freelist_total,
+            schema_cookie,
+            schema_format_num,
+            default_page_cache_size,
+            largest_root,
+            text_encoding,
+            user_version,
+            inc_vacuum_mode,
+            application_id,
+            version_valid_for_number,
+            version,
+        }
+    }
+
+    /// Get real page size
+    ///
+    /// Field stores only 2 bytes, to max value to represent is 65535
+    /// To specify page size of value 65536 - 0x0001 value is used
+    fn to_page_size(value: u16) -> u32 {
+        match value {
+            1 => 65536,
+            v => v as u32,
+        }
+    }
+}
+
+#[test]
+fn header_deserialize_serialize() {
+    let header = serde_sqlite::from_bytes::<Header>(HEADER.as_slice());
+    assert!(header.is_ok(), "{:?}", header);
+    let header = header.unwrap();
+
+    let test_header = <TestHeader as TryFrom<_>>::try_from(&HEADER);
+    assert!(test_header.is_ok(), "{:?}", test_header);
+    let test_header = test_header.unwrap();
+
+    // check magic
+    assert_eq!(header.magic, test_header.magic);
+    assert_eq!(
+        CStr::from_bytes_with_nul(header.magic.as_slice()),
+        CStr::from_bytes_with_nul(b"SQLite format 3\0")
+    );
+
+    // check page size
+    assert_eq!(header.page_size(), test_header.page_size);
+
+    // check write version
+    assert_eq!(header.write_version, test_header.write_version);
+
+    // check read version
+    assert_eq!(header.read_version, test_header.read_version);
+
+    // check max embedded payload fraction
+    assert_eq!(
+        header.max_embedded_payload_fraction,
+        test_header.max_embedded_payload_fraction
+    );
+
+    // check min embedded payload fraction
+    assert_eq!(
+        header.min_embedded_payload_fraction,
+        test_header.min_embedded_payload_fraction
+    );
+
+    // check leaf payload fraction
+    assert_eq!(
+        header.leaf_payload_fraction,
+        test_header.leaf_payload_fraction
+    );
+
+    // check file change counter
+    assert_eq!(header.file_change_counter, test_header.file_change_counter);
+
+    // check db size
+    assert_eq!(header.database_size, test_header.db_size);
+
+    // check first free page num
+    assert_eq!(
+        header.first_freelist_page_num,
+        test_header.first_free_page_num
+    );
+
+    // check freelist total
+    assert_eq!(header.freelist_pages_total, test_header.freelist_total);
+
+    // check schema cookie
+    assert_eq!(header.schema_cookie, test_header.schema_cookie);
+
+    // check schema format num
+    assert_eq!(header.schema_format_num, test_header.schema_format_num);
+
+    // check default page cache size
+    assert_eq!(
+        header.default_page_cache_size,
+        test_header.default_page_cache_size
+    );
+
+    // check largest root
+    assert_eq!(header.largest_root, test_header.largest_root);
+
+    // check text encoding
+    assert_eq!(header.text_encoding, test_header.text_encoding as u32);
+
+    // check user version
+    assert_eq!(header.user_version, test_header.user_version);
+
+    // check inc vacuum mode
+    assert_eq!(header.inc_vacuum_mode, test_header.inc_vacuum_mode);
+
+    // check application id
+    assert_eq!(header.application_id, test_header.application_id);
+
+    // check version valid for number
+    assert_eq!(
+        header.version_valid_for_number,
+        test_header.version_valid_for_number
+    );
+
+    // check version
+    assert_eq!(header.version, test_header.version);
+
+    // check serialized header equals original header
+    let bytes = serde_sqlite::to_bytes(&header);
+    assert!(bytes.is_ok(), "{:?}", bytes);
+    let bytes = bytes.unwrap();
+    assert_eq!(bytes, HEADER);
+}

--- a/serde_sqlite/Cargo.toml
+++ b/serde_sqlite/Cargo.toml
@@ -1,16 +1,10 @@
 [package]
-name = "journal"
+name = "serde_sqlite"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-block = { path = "../block" }
-clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-chrono = "0.4"
-serde_sqlite = { path = "../serde_sqlite" }
-
-[dev-dependencies]
-tempfile = "3"
+block = { path = "../block" }

--- a/serde_sqlite/src/de.rs
+++ b/serde_sqlite/src/de.rs
@@ -1,24 +1,21 @@
-//! Journal Data Format Deserializer
+//! SQLite data format deserializer
 
 use crate::error::Error;
 use block::Block;
-use serde::{
-    de::{self, Deserializer, Visitor},
-    Deserialize,
-};
+use serde::{de, de::Visitor, Deserialize, Deserializer};
 use std::io::Read;
 
-struct De<R> {
+struct SqliteDe<R> {
     reader: R,
 }
 
-impl<R: Read> De<R> {
+impl<R: Read> SqliteDe<R> {
     fn from_reader(reader: R) -> Self {
         Self { reader }
     }
 }
 
-impl<'de, 'a, R> Deserializer<'de> for &'a mut De<R>
+impl<'de, 'a, R> Deserializer<'de> for &'a mut SqliteDe<R>
 where
     R: Read,
 {
@@ -28,7 +25,7 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(Self::Error::Unsupported)
+        Err(Self::Error::Unsupported("Deserializer::deserialize_any"))
     }
 
     fn deserialize_bool<V>(self, v: V) -> Result<V::Value, Self::Error>
@@ -134,70 +131,72 @@ where
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Self::Error::Unsupported("Deserializer::deserialize_char"))
     }
 
     fn deserialize_str<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_str"))
     }
 
     fn deserialize_string<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_string"))
     }
 
     fn deserialize_bytes<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_bytes"))
     }
 
     fn deserialize_byte_buf<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_byte_buf"))
     }
 
     fn deserialize_option<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_option"))
     }
 
     fn deserialize_unit<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_unit"))
     }
 
     fn deserialize_unit_struct<V>(self, _name: &str, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_unit_struct"))
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &str, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported(
+            "Deserializer::deserialize_newtype_struct",
+        ))
     }
 
     fn deserialize_seq<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_seq"))
     }
 
     fn deserialize_tuple<V>(self, len: usize, v: V) -> Result<V::Value, Self::Error>
@@ -216,14 +215,14 @@ where
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_tuple_struct"))
     }
 
     fn deserialize_map<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_map"))
     }
 
     fn deserialize_struct<V>(
@@ -247,27 +246,27 @@ where
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_enum"))
     }
 
     fn deserialize_identifier<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_identifier"))
     }
 
     fn deserialize_ignored_any<V>(self, _v: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("Deserializer::deserialize_ignored_any"))
     }
 }
 
 /// SeqAccess for Visitor
 struct SeqAccess<'a, R: 'a> {
-    de: &'a mut De<R>,
+    de: &'a mut SqliteDe<R>,
     len: usize,
 }
 
@@ -278,7 +277,7 @@ impl<'a, 'de, R: Read> de::SeqAccess<'de> for SeqAccess<'a, R> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        unimplemented!()
+        Err(Error::Unsupported("SeqAccess::next_element"))
     }
 
     fn next_element<T>(&mut self) -> Result<Option<T>, Self::Error>
@@ -294,8 +293,9 @@ impl<'a, 'de, R: Read> de::SeqAccess<'de> for SeqAccess<'a, R> {
     }
 }
 
+
 /// Deserialize default value (zero) as None
-pub fn custom_option<'de, D, T>(d: D) -> Result<Option<T>, D::Error>
+pub fn zero_as_none<'de, D, T>(d: D) -> Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,
     T: Deserialize<'de> + Default + Copy + PartialEq + Eq,
@@ -324,5 +324,5 @@ where
         .map_err(Error::OutOfMemory)?;
     buf.resize(T::block_size(), 0);
     reader.read_exact(&mut buf).map_err(Error::IoError)?;
-    T::deserialize(&mut De::from_reader(std::io::Cursor::new(buf)))
+    T::deserialize(&mut SqliteDe::from_reader(std::io::Cursor::new(buf)))
 }

--- a/serde_sqlite/src/error.rs
+++ b/serde_sqlite/src/error.rs
@@ -1,0 +1,40 @@
+//! Sqlite Data Format Serialize/Deserialize Error
+
+use serde::{de, ser};
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    Message(String),
+    IoError(std::io::Error),
+    Incomplete,
+    Unexpected,
+    Unsupported(&'static str),
+    OutOfMemory(std::collections::TryReserveError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::IoError(e)
+    }
+}

--- a/serde_sqlite/src/lib.rs
+++ b/serde_sqlite/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod de;
+mod error;
+pub mod se;
+
+pub use de::{from_bytes, from_reader};
+pub use error::Error;
+pub use se::to_bytes;

--- a/serde_sqlite/src/se.rs
+++ b/serde_sqlite/src/se.rs
@@ -1,14 +1,18 @@
-///! Journal Data Format Serializer
+///! Sqlite data format serializer
 use crate::error::Error;
 use block::Block;
-use serde::{ser, Serialize};
+use serde::{
+    ser::SerializeMap, ser::SerializeSeq, ser::SerializeStruct, ser::SerializeStructVariant,
+    ser::SerializeTuple, ser::SerializeTupleStruct, ser::SerializeTupleVariant, Serialize,
+    Serializer,
+};
 use std::io::Write;
 
-struct Se<W: Write> {
+struct SqliteSe<W: Write> {
     writer: W,
 }
 
-impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
+impl<'a, W: Write> Serializer for &'a mut SqliteSe<W> {
     type Ok = ();
     type Error = Error;
 
@@ -93,30 +97,28 @@ impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
             .map_err(Into::into)
     }
 
-    // FIXME: not yet supported, and probably, will never be needed
     fn serialize_str(self, _: &str) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_str"))
     }
 
-    // FIXME: not yet supported, and probably, will never be needed
     fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_bytes"))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_none"))
     }
 
     fn serialize_some<T: ?Sized + Serialize>(self, _: &T) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_some"))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_unit"))
     }
 
     fn serialize_unit_struct(self, _name: &str) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_unit_struct"))
     }
 
     fn serialize_unit_variant(
@@ -125,7 +127,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
         _variant_index: u32,
         _variant: &str,
     ) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_unit_variant"))
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -133,7 +135,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
         _name: &str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_newtype_struct"))
     }
 
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
@@ -143,7 +145,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
         _variant: &str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("Serializer::serialize_newtype_variant"))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
@@ -195,7 +197,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Se<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeSeq for &'a mut Se<W> {
+impl<'a, W: Write> SerializeSeq for &'a mut SqliteSe<W> {
     type Ok = ();
     type Error = Error;
 
@@ -203,78 +205,23 @@ impl<'a, W: Write> ser::SerializeSeq for &'a mut Se<W> {
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        Err(Error::Unsupported("SerializeSeq::serialize_element"))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("SerializeSeq::end"))
     }
 }
 
-impl<'a, W: Write> ser::SerializeTuple for &'a mut Se<W> {
+impl<'a, W: Write> SerializeTuple for &'a mut SqliteSe<W> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
-    }
-}
-
-impl<'a, W: Write> ser::SerializeTupleStruct for &'a mut Se<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        unimplemented!()
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
-    }
-}
-
-impl<'a, W: Write> ser::SerializeTupleVariant for &'a mut Se<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        unimplemented!()
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
-    }
-}
-
-impl<'a, W: Write> ser::SerializeMap for &'a mut Se<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_key<T>(&mut self, _key: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        unimplemented!()
-    }
-
-    fn serialize_value<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        unimplemented!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
@@ -282,7 +229,62 @@ impl<'a, W: Write> ser::SerializeMap for &'a mut Se<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeStruct for &'a mut Se<W> {
+impl<'a, W: Write> SerializeTupleStruct for &'a mut SqliteSe<W> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("SerializeTupleStruct::serialize_field"))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("SerializeTupleStruct::end"))
+    }
+}
+
+impl<'a, W: Write> SerializeTupleVariant for &'a mut SqliteSe<W> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("SerializeTupleVariant::serialize_field"))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("SerializeTupleVariant::end"))
+    }
+}
+
+impl<'a, W: Write> SerializeMap for &'a mut SqliteSe<W> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, _key: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("SerializeMap::serialize_key"))
+    }
+
+    fn serialize_value<T>(&mut self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(Error::Unsupported("SerializeMap::serialize_value"))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("SerializeMap::end"))
+    }
+}
+
+impl<'a, W: Write> SerializeStruct for &'a mut SqliteSe<W> {
     type Ok = ();
     type Error = Error;
 
@@ -298,7 +300,7 @@ impl<'a, W: Write> ser::SerializeStruct for &'a mut Se<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeStructVariant for &'a mut Se<W> {
+impl<'a, W: Write> SerializeStructVariant for &'a mut SqliteSe<W> {
     type Ok = ();
     type Error = Error;
 
@@ -306,18 +308,20 @@ impl<'a, W: Write> ser::SerializeStructVariant for &'a mut Se<W> {
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        Err(Error::Unsupported(
+            "SerializeStructVariant::serialize_field",
+        ))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        Err(Error::Unsupported("SerializeStructVariant::end"))
     }
 }
 
-/// serialize None as zero
-pub fn custom_option<S, T>(field: &Option<T>, s: S) -> Result<S::Ok, S::Error>
+// serialize None as zero
+pub fn none_as_zero<S, T>(field: &Option<T>, s: S) -> Result<S::Ok, S::Error>
 where
-    S: ser::Serializer,
+    S: Serializer,
     T: Serialize + Copy + Default,
 {
     let value = match field.as_ref() {
@@ -339,11 +343,10 @@ where
     Ok(buf)
 }
 
-// FIXME:
-// this func doesn't check block if block was fully written
+// FIXME: this func doesn't perform write for a whole block, so not pub.
 fn to_writer<T, W: Write>(writer: W, value: &T) -> Result<(), Error>
 where
     T: Serialize,
 {
-    value.serialize(&mut Se { writer })
+    value.serialize(&mut SqliteSe { writer })
 }

--- a/serde_sqlite/tests/de_test.rs
+++ b/serde_sqlite/tests/de_test.rs
@@ -1,6 +1,6 @@
-use block::{block, Block};
-use journal::Error;
-use journal::{from_bytes, from_reader};
+use block::block;
+use serde_sqlite::Error;
+use serde_sqlite::{from_bytes, from_reader};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -17,16 +17,16 @@ struct ValidStruct {
     i_64: i64,
     f_32: f32,
     f_64: f64,
-    #[serde(deserialize_with = "journal::de::custom_option")]
+    #[serde(deserialize_with = "serde_sqlite::de::zero_as_none")]
     n: Option<u64>,
-    #[serde(deserialize_with = "journal::de::custom_option")]
+    #[serde(deserialize_with = "serde_sqlite::de::zero_as_none")]
     s: Option<u64>,
 }
 
 #[test]
 #[rustfmt::skip]
 fn test_deserialization_from_bytes() {
-    let block = &[ 
+    let block = &[
         /* b       */ 0x01,
         /* u_8     */ 0x02,
         /* u_16    */ 0x01, 0x02,
@@ -40,7 +40,7 @@ fn test_deserialization_from_bytes() {
         /* f_64    */ 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         /* n<u64>  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         /* s<u64>  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-        /* block   */ 
+        /* block   */
         /* padding */ 0x01, 0x02, 0x03, 0x04, 0x05
     ];
     let decoded = from_bytes::<ValidStruct>(block);
@@ -67,7 +67,7 @@ fn test_deserialization_from_bytes() {
 #[test]
 #[rustfmt::skip]
 fn test_deserialization_from_reader() {
-    let block = &[ 
+    let block = &[
         /* b       */ 0x01,
         /* u_8     */ 0x02,
         /* u_16    */ 0x01, 0x02,
@@ -81,7 +81,7 @@ fn test_deserialization_from_reader() {
         /* f_64    */ 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         /* n<u64>  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         /* s<u64>  */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-        /* block   */ 
+        /* block   */
         /* padding */ 0x00, 0x00, 0x00, 0x00, 0x00
     ];
     let decoded = from_reader::<ValidStruct, _>(std::io::Cursor::new(block));
@@ -109,7 +109,7 @@ fn test_deserialization_from_reader() {
 #[rustfmt::skip]
 fn test_deserialization_error() {
     // incomplete block (padding is missing)
-    let block = &[ 
+    let block = &[
         /* b       */ 0x01,
         /* u_8     */ 0x02,
         /* u_16    */ 0x01, 0x02,

--- a/serde_sqlite/tests/se_test.rs
+++ b/serde_sqlite/tests/se_test.rs
@@ -1,5 +1,5 @@
 use block::{block, Block};
-use journal::{to_bytes, Error};
+use serde_sqlite::{to_bytes, Error};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -16,9 +16,9 @@ struct ValidStruct {
     i_64: i64,
     f_32: f32,
     f_64: f64,
-    #[serde(serialize_with = "journal::se::custom_option")]
+    #[serde(serialize_with = "serde_sqlite::se::none_as_zero")]
     n: Option<u64>,
-    #[serde(serialize_with = "journal::se::custom_option")]
+    #[serde(serialize_with = "serde_sqlite::se::none_as_zero")]
     s: Option<u64>,
 }
 


### PR DESCRIPTION
Adds serde_sqlite crate and add page_parser crate. 
Data format was moved from journal to serde_sqlite. 
Page parser added and is able to parse sqlite database header.